### PR TITLE
Don't error on 204 - no content (nothing playing)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "platformio.platformio-ide"
+    ]
+}

--- a/src/ArduinoSpotify.cpp
+++ b/src/ArduinoSpotify.cpp
@@ -434,6 +434,7 @@ CurrentlyPlaying ArduinoSpotify::getCurrentlyPlaying(const char *market)
     if (statusCode > 0)
     {
         skipHeaders();
+        currentlyPlaying.statusCode = statusCode;
     }
 
     if (statusCode == 200)
@@ -493,6 +494,10 @@ CurrentlyPlaying ArduinoSpotify::getCurrentlyPlaying(const char *market)
             Serial.println(error.c_str());
         }
     }
+    if (statusCode == 204)
+    {
+        currentlyPlaying.error = false;
+    }
     closeClient();
     return currentlyPlaying;
 }
@@ -525,6 +530,7 @@ PlayerDetails ArduinoSpotify::getPlayerDetails(const char *market)
     if (statusCode > 0)
     {
         skipHeaders();
+        playerDetails.statusCode = statusCode;
     }
 
     if (statusCode == 200)
@@ -573,6 +579,10 @@ PlayerDetails ArduinoSpotify::getPlayerDetails(const char *market)
             Serial.print(F("deserializeJson() failed with code "));
             Serial.println(error.c_str());
         }
+    }
+    if (statusCode == 204)
+    {
+        playerDetails.error = false;
     }
     closeClient();
     return playerDetails;

--- a/src/ArduinoSpotify.h
+++ b/src/ArduinoSpotify.h
@@ -91,6 +91,7 @@ struct PlayerDetails
   RepeatOptions repeateState;
   bool shuffleState;
 
+  int statusCode;
   bool error;
 };
 
@@ -108,6 +109,7 @@ struct CurrentlyPlaying
   long progressMs;
   long duraitonMs;
 
+  int statusCode;
   bool error;
 };
 


### PR DESCRIPTION
- Creates a `currentlyPlaying.statusCode` and `playerDetails.statusCode` int
- `.error = false` on a 204 response (no content) for differentiation between an actual error and nothing playing/no active Spotify sessions